### PR TITLE
Arrange action refactored

### DIFF
--- a/JHotDraw/nb-configuration.xml
+++ b/JHotDraw/nb-configuration.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project-shared-configuration>
+    <!--
+This file contains additional configuration written by modules in the NetBeans IDE.
+The configuration is intended to be shared among all the users of project and
+therefore it is assumed to be part of version control checkout.
+Without this configuration present, some functionality in the IDE may be limited or fail altogether.
+-->
+    <properties xmlns="http://www.netbeans.org/ns/maven-properties-data/1">
+        <!--
+Properties that influence various parts of the IDE, especially code formatting and the like. 
+You can copy and paste the single properties, into the pom.xml file and the IDE will pick them up.
+That way multiple projects can share the same settings (useful for formatting rules for example).
+Any value defined here will override the pom.xml file value but is only applicable to the current project.
+-->
+        <netbeans.hint.jdkPlatform>JDK_15</netbeans.hint.jdkPlatform>
+    </properties>
+</project-shared-configuration>

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/AbstractCompositeFigure.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/AbstractCompositeFigure.java
@@ -33,9 +33,7 @@ import static org.jhotdraw.draw.AttributeKeys.*;
  * <br>1.0.1 2008-03-30 Made basicRemove method non-final.
  * <br>1.0 July 17, 2007 Created.
  */
-public abstract class AbstractCompositeFigure
-        extends AbstractFigure
-        implements CompositeFigure {
+public abstract class AbstractCompositeFigure extends AbstractFigure implements CompositeFigure {
 
     /**
      * A Layouter determines how the children of the CompositeFigure

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/QuadTreeDrawing.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/QuadTreeDrawing.java
@@ -257,6 +257,7 @@ public class QuadTreeDrawing extends AbstractDrawing {
         }
     }
 
+    
     @Override
     @FeatureEntryPoint(JHotDrawFeatures.ARRANGE)
     public void sendToBack(Figure figure) {

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/AbstractSelectedAction.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/AbstractSelectedAction.java
@@ -11,7 +11,6 @@
  * accordance with the license agreement you entered into with  
  * the copyright holders. For details see accompanying license terms. 
  */
-
 package org.jhotdraw.draw.action;
 
 import org.jhotdraw.draw.Drawing;
@@ -25,27 +24,29 @@ import java.io.Serializable;
 import javax.swing.undo.*;
 import org.jhotdraw.util.*;
 import java.util.*;
+
 /**
- * Abstract super class for actions which act on the selected figures of a drawing
- * editor. If no figures are selected, the action is disabled.
+ * Abstract super class for actions which act on the selected figures of a
+ * drawing editor. If no figures are selected, the action is disabled.
  *
  * @author Werner Randelshofer
  *
  * @version 3.1.2 2008-06-08 Method setEditor did not register the EventHandler
  * to the active view of the editor.
- * <br>3.1.1. 2006-07-09 Fixed enabled state. 
+ * <br>3.1.1. 2006-07-09 Fixed enabled state.
  * <br>3.1 2006-03-15 Support for enabled state of view added.
  * <br>3.0 2006-02-24 Changed to support multiple views.
  * <br>2.0 2006-02-14 Updated to work with multiple views.
  * <br>1.0 2003-12-01 Created.
  */
-public abstract class AbstractSelectedAction
-        extends AbstractAction  {
+public abstract class AbstractSelectedAction extends AbstractAction {
+
     private DrawingEditor editor;
-    protected ResourceBundleUtil labels =
-            ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels", Locale.getDefault());
-    
+    protected ResourceBundleUtil labels
+            = ResourceBundleUtil.getBundle("org.jhotdraw.draw.Labels", Locale.getDefault());
+
     private class EventHandler implements PropertyChangeListener, FigureSelectionListener, Serializable {
+
         public void propertyChange(PropertyChangeEvent evt) {
             if (evt.getPropertyName() == DrawingEditor.ACTIVE_VIEW_PROPERTY) {
                 if (evt.getOldValue() != null) {
@@ -63,33 +64,34 @@ public abstract class AbstractSelectedAction
                 updateEnabledState();
             }
         }
+
         public void selectionChanged(FigureSelectionEvent evt) {
             updateEnabledState();
-            
+
         }
     };
-    
+
     private EventHandler eventHandler = new EventHandler();
-    
-    
-    /** Creates an action which acts on the selected figures on the current view
+
+    /**
+     * Creates an action which acts on the selected figures on the current view
      * of the specified editor.
      */
     public AbstractSelectedAction(DrawingEditor editor) {
         setEditor(editor);
         updateEnabledState();
     }
-    
+
     protected void updateEnabledState() {
         if (getView() != null) {
-            setEnabled(getView().isEnabled() &&
-                    getView().getSelectionCount() > 0
-                    );
+            setEnabled(getView().isEnabled()
+                    && getView().getSelectionCount() > 0
+            );
         } else {
             setEnabled(false);
         }
     }
-    
+
     public void dispose() {
         if (this.editor != null) {
             this.editor.removePropertyChangeListener(eventHandler);
@@ -99,7 +101,7 @@ public abstract class AbstractSelectedAction
         }
         this.editor = null;
     }
-    
+
     public void setEditor(DrawingEditor editor) {
         if (this.editor != null) {
             this.editor.removePropertyChangeListener(eventHandler);
@@ -116,18 +118,21 @@ public abstract class AbstractSelectedAction
         }
         updateEnabledState();
     }
-    
+
     public DrawingEditor getEditor() {
         return editor;
     }
+
     protected DrawingView getView() {
         return (editor == null) ? null : editor.getActiveView();
     }
+
     protected Drawing getDrawing() {
         return (getView() == null) ? null : getView().getDrawing();
     }
+
     protected void fireUndoableEditHappened(UndoableEdit edit) {
         getDrawing().fireUndoableEditHappened(edit);
     }
-    
+
 }

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/ButtonFactory.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/ButtonFactory.java
@@ -236,7 +236,7 @@ public class ButtonFactory {
 
         a.add(null); // separator
 
-        a.add(new BringToFrontAction(editor));
+        a.add(new SendToFrontAction(editor));
         a.add(new SendToBackAction(editor));
 
         return a;
@@ -1386,7 +1386,7 @@ public class ButtonFactory {
         bar.add(new MoveAction.North(editor)).setFocusable(false);
         bar.add(new MoveAction.South(editor)).setFocusable(false);
         bar.addSeparator();
-        bar.add(new BringToFrontAction(editor)).setFocusable(false);
+        bar.add(new SendToFrontAction(editor)).setFocusable(false);
         bar.add(new SendToBackAction(editor)).setFocusable(false);
 
     }

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/SendToBackAction.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/SendToBackAction.java
@@ -11,7 +11,6 @@
  * accordance with the license agreement you entered into with  
  * the copyright holders. For details see accompanying license terms. 
  */
-
 package org.jhotdraw.draw.action;
 
 import dk.sdu.mmmi.featuretracer.lib.FeatureEntryPoint;
@@ -25,43 +24,57 @@ import org.jhotdraw.draw.*;
 /**
  * SendToBackAction.
  *
- * @author  Werner Randelshofer
- * @version 2.0 2008-05-30 Renamed from MoveToBackAction to SendToBackAction
- * for consistency with the API of Drawing.
- * <br>1.0 24. November 2003  Created.
+ * @author Werner Randelshofer
+ * @version 2.0 2008-05-30 Renamed from MoveToBackAction to SendToBackAction for
+ * consistency with the API of Drawing.
+ * <br>1.0 24. November 2003 Created.
  */
 public class SendToBackAction extends AbstractSelectedAction {
-    
-       public static String ID = "edit.sendToBack";
-    /** Creates a new instance. */
+
+    public static String ID = "edit.sendToBack";
+
+    /**
+     * Creates a new instance.
+     */
     public SendToBackAction(DrawingEditor editor) {
         super(editor);
         labels.configureAction(this, ID);
     }
 
     @FeatureEntryPoint(JHotDrawFeatures.ARRANGE)
+    @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         final DrawingView view = getView();
         final LinkedList<Figure> figures = new LinkedList<Figure>(view.getSelectedFigures());
         sendToBack(view, figures);
-        fireUndoableEditHappened(new AbstractUndoableEdit() {
+        fireUndoableEditHappened(setupUndoableEditOverrides(view, figures));
+
+    }
+
+    public AbstractUndoableEdit setupUndoableEditOverrides(DrawingView view, Collection figures) {
+        AbstractUndoableEdit undoableEdit = new AbstractUndoableEdit() {
             @Override
             public String getPresentationName() {
-       return labels.getTextProperty(ID);
+                System.out.println("Undoable Edit from send to back, label: " + ID + " " + labels.getTextProperty(ID));
+                return labels.getTextProperty(ID);
             }
+
             @Override
             public void redo() throws CannotRedoException {
                 super.redo();
                 SendToBackAction.sendToBack(view, figures);
             }
+
             @Override
             public void undo() throws CannotUndoException {
                 super.undo();
-                BringToFrontAction.bringToFront(view, figures);
+                SendToFrontAction.sendToFront(view, figures);
             }
-        }
-        );
+        };
+         
+         return undoableEdit;
     }
+
     public static void sendToBack(DrawingView view, Collection figures) {
         Iterator i = figures.iterator();
         Drawing drawing = view.getDrawing();

--- a/JHotDraw/src/main/java/org/jhotdraw/draw/action/SendToFrontAction.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/draw/action/SendToFrontAction.java
@@ -1,5 +1,5 @@
 /*
- * @(#)BringToFrontAction.java  2.0  2008-05-30
+ * @(#)SendToFrontAction.java  2.0  2008-05-30
  *
  * Copyright (c) 2003-2008 by the original authors of JHotDraw
  * and all its contributors.
@@ -11,7 +11,6 @@
  * accordance with the license agreement you entered into with  
  * the copyright holders. For details see accompanying license terms. 
  */
-
 package org.jhotdraw.draw.action;
 
 import dk.sdu.mmmi.featuretracer.lib.FeatureEntryPoint;
@@ -25,46 +24,56 @@ import org.jhotdraw.draw.*;
 /**
  * ToFrontAction.
  *
- * @author  Werner Randelshofer
- * @version 2.0 2008-05-30 Renamed from MoveToFrontAction to BringToFrontAction
- * for consistency with the API of Drawing. 
- * <br>1.0 24. November 2003  Created.
+ * @author Werner Randelshofer
+ * @version 2.0 2008-05-30 Renamed from MoveToFrontAction to SendToFrontAction
+ * for consistency with the API of Drawing.
+ * <br>1.0 24. November 2003 Created.
  */
-public class BringToFrontAction extends AbstractSelectedAction {
-    
-       public static String ID = "edit.bringToFront";
-       
-    /** Creates a new instance. */
-    public BringToFrontAction(DrawingEditor editor) {
+public class SendToFrontAction extends AbstractSelectedAction {
+
+    public static String ID = "edit.bringToFront";
+
+    /**
+     * Creates a new instance.
+     */
+    public SendToFrontAction(DrawingEditor editor) {
         super(editor);
         labels.configureAction(this, ID);
     }
 
     @FeatureEntryPoint(JHotDrawFeatures.ARRANGE)
+    @Override
     public void actionPerformed(java.awt.event.ActionEvent e) {
         final DrawingView view = getView();
         final LinkedList<Figure> figures = new LinkedList<Figure>(view.getSelectedFigures());
-        bringToFront(view, figures);
-        fireUndoableEditHappened(new AbstractUndoableEdit() {
+        sendToFront(view, figures);
+        fireUndoableEditHappened(setupUndoableEditOverrides(view, figures));
+    }
+
+    public AbstractUndoableEdit setupUndoableEditOverrides(DrawingView view, Collection figures) {
+        AbstractUndoableEdit undoableEdit = new AbstractUndoableEdit() {
             @Override
             public String getPresentationName() {
-       return labels.getTextProperty(ID);
+                System.out.println("Undoable Edit from send to front, label: " + ID + " " + labels.getTextProperty(ID));
+                return labels.getTextProperty(ID);
             }
+
             @Override
             public void redo() throws CannotRedoException {
                 super.redo();
-                BringToFrontAction.bringToFront(view, figures);
+                SendToFrontAction.sendToFront(view, figures);
             }
+
             @Override
             public void undo() throws CannotUndoException {
                 super.undo();
                 SendToBackAction.sendToBack(view, figures);
             }
-        }
-        
-        );
+        };
+        return undoableEdit;
     }
-    public static void bringToFront(DrawingView view, Collection<Figure> figures) {
+
+    public static void sendToFront(DrawingView view, Collection<Figure> figures) {
         Drawing drawing = view.getDrawing();
         Iterator i = drawing.sort(figures).iterator();
         while (i.hasNext()) {
@@ -72,5 +81,5 @@ public class BringToFrontAction extends AbstractSelectedAction {
             drawing.bringToFront(figure);
         }
     }
-    
+
 }

--- a/JHotDraw/src/main/java/org/jhotdraw/samples/svg/SVGApplicationModel.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/samples/svg/SVGApplicationModel.java
@@ -97,7 +97,7 @@ public class SVGApplicationModel extends DefaultApplicationModel {
         a.add(new SplitAction(editor));
 
         a.add(null); // separator
-        a.add(new BringToFrontAction(editor));
+        a.add(new SendToFrontAction(editor));
         a.add(new SendToBackAction(editor));
 
         return a;

--- a/JHotDraw/src/main/java/org/jhotdraw/samples/svg/gui/ArrangeToolBar.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/samples/svg/gui/ArrangeToolBar.java
@@ -84,10 +84,10 @@ public class ArrangeToolBar extends AbstractToolBar {
                     GridBagConstraints gbc;
                     AbstractButton btn;
 
-                    btn = new JButton(new BringToFrontAction(editor));
+                    btn = new JButton(new SendToFrontAction(editor));
                     btn.setUI((PaletteButtonUI) PaletteButtonUI.createUI(btn));
                     btn.setText(null);
-                    labels.configureToolBarButton(btn, BringToFrontAction.ID);
+                    labels.configureToolBarButton(btn, SendToFrontAction.ID);
                     btn.putClientProperty("hideActionText", Boolean.TRUE);
                     gbc = new GridBagConstraints();
                     gbc.gridy = 0;

--- a/JHotDraw/src/main/java/org/jhotdraw/samples/svg/gui/ToolsToolBar.java
+++ b/JHotDraw/src/main/java/org/jhotdraw/samples/svg/gui/ToolsToolBar.java
@@ -179,7 +179,7 @@ public class ToolsToolBar extends AbstractToolBar {
 
         a.add(null); // separator
 
-        a.add(new BringToFrontAction(editor));
+        a.add(new SendToFrontAction(editor));
         a.add(new SendToBackAction(editor));
 
         return a;

--- a/JHotDraw/src/main/resources/org/jhotdraw/samples/svg/Labels.properties
+++ b/JHotDraw/src/main/resources/org/jhotdraw/samples/svg/Labels.properties
@@ -16,11 +16,11 @@ edit.removeTransform.text=Remove Transformation
 
 saveDrawing=Save
 
-edit.bringToFront.toolTipText=Bring to Front
+edit.bringToFront.toolTipText=Send to Front
 
 edit.bringToFront.icon=${imageDir}/moveToFront.png
 
-edit.bringToFront.text=Bring to Front
+edit.bringToFront.text=Send to Front
 
 edit.sendToBack.text=Send to Back
 
@@ -114,7 +114,7 @@ attribute.strokeDashes.toolTipText=Line Dashes
 
 attribute.strokeDashes.icon=${imageDir}/attributeStrokeDashes.png
 
-moveToFront.toolTipText=Bring to Front
+moveToFront.toolTipText=Send to Front
 
 moveToFront.icon=${imageDir}/moveToFront.png
 
@@ -192,7 +192,7 @@ attributesPick.toolTipText=Pick attributes
 
 attributesPick.icon=${imageDir}/attributesPick.png
 
-moveToFront=Bring to Front
+moveToFront=Send to Front
 
 moveToBack=Send to Back
 

--- a/JHotDraw/src/main/resources/org/jhotdraw/samples/svg/Labels_en_US.properties
+++ b/JHotDraw/src/main/resources/org/jhotdraw/samples/svg/Labels_en_US.properties
@@ -16,11 +16,11 @@ edit.removeTransform.text=Remove Transformation
 
 saveDrawing=Save
 
-edit.bringToFront.toolTipText=Bring to Front
+edit.sendToFront.toolTipText=Send to Front
 
-edit.bringToFront.icon=${imageDir}/moveToFront.png
+edit.sendToFront.icon=${imageDir}/moveToFront.png
 
-edit.bringToFront.text=Bring to Front
+edit.sendToFront.text=Send to Front
 
 edit.sendToBack.text=Send to Back
 
@@ -114,7 +114,7 @@ attribute.strokeDashes.toolTipText=Line Dashes
 
 attribute.strokeDashes.icon=${imageDir}/attributeStrokeDashes.png
 
-moveToFront.toolTipText=Bring to Front
+moveToFront.toolTipText=Send to Front
 
 moveToFront.icon=${imageDir}/moveToFront.png
 
@@ -192,7 +192,7 @@ attributesPick.toolTipText=Pick attributes
 
 attributesPick.icon=${imageDir}/attributesPick.png
 
-moveToFront=Bring to Front
+moveToFront=Send to Front
 
 moveToBack=Send to Back
 


### PR DESCRIPTION
I renamed the BringToFront action to SendToFront to keep the arrange actions' names uniform. In the now SendToFront and SendToBack action classes, I extracted a method in both classes which also left the original method as a composed method where the level of details is uniform throughout the method.

I have tried to change the label property files so my change of the BringToFront name also can be seen in the GUI as I want to keep it consistent in the whole system. I think I have located the specific file where the change is supposed to go, but I am not seeing the change in the GUI - for now, I don't know why. Maybe some cache stuff?